### PR TITLE
Rename "ApplyTitleCase" & "AnalyzeText"

### DIFF
--- a/Source/Init.lua
+++ b/Source/Init.lua
@@ -323,10 +323,10 @@ function StringPlus.UniqueWords(Str: string, ReturnString: boolean?)
 	return (not ReturnString and UniqueWords) or table.concat(UniqueWords, (" "))
 end
 
---[[ AnalyzeText - Calculates statistical information about a string.
+--[[ Analyze - Calculates statistical information about a string.
 -| @param	Str: The input string.
 -| @return	A table containing statistical information about the input string, including the number of characters, words, unique words, vowels, consonants, and lines in the string, as well as a count of the number of times each word appears in the string.]]
-function StringPlus.AnalyzeText(Str: string)
+function StringPlus.Analyze(Str: string)
 	local Num_Chars, Num_Alpha = #Str, 0
 	local Num_Lines, Num_Words = 0, 0
 	local Num_Digits, Num_Punctuation = 0, 0
@@ -460,11 +460,11 @@ function StringPlus.Expand(Str: string, Subset: {[string | number]: any})
 	return Str
 end
 
---[[ ApplyTitleCase - Converts a string to title case, with optional strict adherence to title case rules.
+--[[ TitleCase - Converts a string to title case, with optional strict adherence to title case rules.
 -| @param	Str: The input string.
 -| @param	Strict (optional): Specifies whether to strictly adhere to title case rules. If this parameter is not provided, or is set to false, words that are exempt from title casing its first character will be upper-cased. If Strict is set to true, exempt words would be lower-cased.
 -| @return	The input string in title case.]]
-function StringPlus.ApplyTitleCase(Str: string, Strict: boolean?): string
+function StringPlus.TitleCase(Str: string, Strict: boolean?): string
 	local StrArray = {}
 	local TitleCasePreservations = {
 		"a", "an", "and", "or", "the", "but", "in", "on", "for", "up",

--- a/Source/TypeChecking.lua
+++ b/Source/TypeChecking.lua
@@ -58,7 +58,7 @@ export type StringPlusPascal = {
 	SnakeCase: (Str: string) -> string,
 	UniqueWords: (Str: string, ReturnString: boolean?) -> ({string} | string),
 	Expand: (Str: string, Subset: {[string | number]: any}) -> string,
-	ApplyTitleCase: (Str: string, Strict: boolean?) -> string,
+	TitleCase: (Str: string, Strict: boolean?) -> string,
 	Lines: (Str: string, KeepEnds: boolean?, ReturnAsATuple: boolean?) -> (...string | {string}),
 	RFind: (Str: string, Sub: string, Start: number?, End: number?) -> (number?, number?),
 	Partition: (Str: string, Separator: string, ReturnAsATuple: boolean?) -> (...string | {string}),
@@ -67,7 +67,7 @@ export type StringPlusPascal = {
 	BinaryDecode: (BinaryStr: string) -> string,
 	HexEncode: (Str: string) -> string,
 	HexDecode: (HexStr: string) -> string?,
-	AnalyzeText: (Str: string) -> {
+	Analyze: (Str: string) -> {
 		LineCount: number,
 		WordCount: number,
 		AvgWordLength: number,
@@ -164,7 +164,7 @@ export type StringPlusLowered = {
 	snakecase: (Str: string) -> string,
 	uniquewords: (Str: string, ReturnString: boolean?) -> ({string} | string),
 	expand: (Str: string, Subset: {[string | number]: any}) -> string,
-	applytitlecase: (Str: string, Strict: boolean?) -> string,
+	titlecase: (Str: string, Strict: boolean?) -> string,
 	lines: (Str: string, KeepEnds: boolean?, ReturnAsATuple: boolean?) -> (...string | {string}),
 	rfind: (Str: string, Sub: string, Start: number?, End: number?) -> (number?, number?),
 	partition: (Str: string, Separator: string, ReturnAsATuple: boolean?) -> (...string | {string}),
@@ -173,7 +173,7 @@ export type StringPlusLowered = {
 	binarydecode: (BinaryStr: string) -> string,
 	hexencode: (Str: string) -> string,
 	hexdecode: (HexStr: string) -> string?,
-	analyzetext: (Str: string) -> {
+	analyze: (Str: string) -> {
 		LineCount: number,
 		WordCount: number,
 		AvgWordLength: number,
@@ -270,7 +270,7 @@ export type StringPlusCamel = {
 	snakeCase: (Str: string) -> string,
 	uniqueWords: (Str: string, ReturnString: boolean?) -> ({string} | string),
 	expand: (Str: string, Subset: {[string | number]: any}) -> string,
-	applyTitleCase: (Str: string, Strict: boolean?) -> string,
+	titleCase: (Str: string, Strict: boolean?) -> string,
 	lines: (Str: string, KeepEnds: boolean?, ReturnAsATuple: boolean?) -> (...string | {string}),
 	rFind: (Str: string, Sub: string, Start: number?, End: number?) -> (number?, number?),
 	partition: (Str: string, Separator: string, ReturnAsATuple: boolean?) -> (...string | {string}),
@@ -279,7 +279,7 @@ export type StringPlusCamel = {
 	binaryDecode: (BinaryStr: string) -> string,
 	hexEncode: (Str: string) -> string,
 	hexDecode: (HexStr: string) -> string?,
-	analyzeText: (Str: string) -> {
+	analyze: (Str: string) -> {
 		LineCount: number,
 		WordCount: number,
 		AvgWordLength: number,

--- a/Source/[Extended] - Validator.lua
+++ b/Source/[Extended] - Validator.lua
@@ -16,7 +16,7 @@ function String.IsNumeric(Str: string)
 	return (tonumber(Str) ~= nil or string.match(Str, "^%s*[+-]?%d*%.?%d+%s*$") ~= nil)
 end
 
---[[ IsNumeric - Returns a boolean value indicating whether the given string contains only integer characters (+,-,0-9).
+--[[ IsInteger - Returns a boolean value indicating whether the given string contains only integer characters (+,-,0-9).
 ---| @examples:	100: true, -100: true, +100: true, 10.0: false, "  .568": false,"  1": false
 -| @param	Str: The string to check if it contains numeric characters.
 -| @return	boolean: True if the string contains only numeric characters, false otherwise.]]


### PR DESCRIPTION
Renamed both functions so that their names are now "TitleCase" and "Analyze" for better declaration of them.

Side modification: fixed an inline comment in the validator module.